### PR TITLE
Fix qtfred help

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -85,7 +85,7 @@ cf_pathtype Pathtypes[CF_MAX_PATH_TYPES]  = {
 	{ CF_TYPE_INTEL_ANIMS,			"data" DIR_SEPARATOR_STR "intelanims",										".pcx .ani .eff .tga .jpg .png .dds",	CF_TYPE_DATA	},
 	{ CF_TYPE_SCRIPTS,				"data" DIR_SEPARATOR_STR "scripts",											".lua .lc .fnl",						CF_TYPE_DATA	},
 	{ CF_TYPE_FICTION,				"data" DIR_SEPARATOR_STR "fiction",											".txt",								CF_TYPE_DATA	}, 
-	{ CF_TYPE_FREDDOCS,				"data" DIR_SEPARATOR_STR "freddocs",										".html .qch .css .png .jpg",	CF_TYPE_DATA	}
+	{ CF_TYPE_FREDDOCS,				"data" DIR_SEPARATOR_STR "freddocs",										".html .css .png .jpg",	CF_TYPE_DATA	}
 };
 // clang-format on
 

--- a/qtfred/CMakeLists.txt
+++ b/qtfred/CMakeLists.txt
@@ -74,13 +74,28 @@ find_program(QHELPGENERATOR_EXECUTABLE
     HINTS "${_QTFRED_QT_BINS}"
     REQUIRED)
 
-set(QTFRED_HELP_QHP "${CMAKE_CURRENT_SOURCE_DIR}/help-src/doc/qtfred.qhp")
-set(QTFRED_HELP_QCH "${CMAKE_CURRENT_BINARY_DIR}/qtfred_help.qch")
+set(QTFRED_HELP_QHP  "${CMAKE_CURRENT_SOURCE_DIR}/help-src/doc/qtfred.qhp")
+set(QTFRED_HELP_QCH  "${CMAKE_CURRENT_BINARY_DIR}/qtfred_help.qch")
+set(QTFRED_HELP_QHCP "${CMAKE_CURRENT_BINARY_DIR}/qtfred_help.qhcp")
+set(QTFRED_HELP_QHC  "${CMAKE_CURRENT_BINARY_DIR}/qtfred_help.qhc")
 
 file(GLOB_RECURSE QTFRED_HELP_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/help-src/doc/*.html"
     "${CMAKE_CURRENT_SOURCE_DIR}/help-src/doc/*.css"
     "${CMAKE_CURRENT_SOURCE_DIR}/help-src/doc/*.qhp")
+
+# Collection project file pointing at the generated .qch (relative path is
+# resolved relative to the .qhcp's directory, so both live in the build dir).
+file(GENERATE OUTPUT "${QTFRED_HELP_QHCP}" CONTENT
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<QHelpCollectionProject version=\"1.0\">
+    <docFiles>
+        <register>
+            <file>qtfred_help.qch</file>
+        </register>
+    </docFiles>
+</QHelpCollectionProject>
+")
 
 # qhelpgenerator is a Qt application and needs a platform plugin at build time.
 # On headless Linux CI the Qt platform plugins fail to dlopen because the Qt
@@ -94,11 +109,24 @@ add_custom_command(
         "LD_LIBRARY_PATH=${_QTFRED_QT_LIBS}"
         "${QHELPGENERATOR_EXECUTABLE}" "${QTFRED_HELP_QHP}" -o "${QTFRED_HELP_QCH}"
     DEPENDS ${QTFRED_HELP_SOURCES}
-    COMMENT "Compiling QtFRED help (qtfred_help.qch)"
+    COMMENT "Compiling QtFRED help content (qtfred_help.qch)"
+    VERBATIM)
+
+# Pre-build the collection (.qhc) with the .qch already registered.  Runtime
+# just opens this in read-only mode -- no QHelpEngine::registerDocumentation
+# bootstrap, which is unreliable on a fresh .qhc under Qt6.
+add_custom_command(
+    OUTPUT "${QTFRED_HELP_QHC}"
+    COMMAND ${CMAKE_COMMAND} -E env
+        "QT_QPA_PLATFORM=offscreen"
+        "LD_LIBRARY_PATH=${_QTFRED_QT_LIBS}"
+        "${QHELPGENERATOR_EXECUTABLE}" "${QTFRED_HELP_QHCP}" -o "${QTFRED_HELP_QHC}"
+    DEPENDS "${QTFRED_HELP_QCH}" "${QTFRED_HELP_QHCP}"
+    COMMENT "Compiling QtFRED help collection (qtfred_help.qhc)"
     VERBATIM)
 
 add_custom_target(qtfred_help
-    DEPENDS "${QTFRED_HELP_QCH}"
+    DEPENDS "${QTFRED_HELP_QCH}" "${QTFRED_HELP_QHC}"
     SOURCES ${QTFRED_HELP_SOURCES})
 
 add_dependencies(qtfred qtfred_help)
@@ -108,14 +136,18 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/help-src"
     FILES ${QTFRED_HELP_SOURCES})
 
 add_custom_command(TARGET qtfred_help POST_BUILD
-
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_FILE_DIR:qtfred>/help"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${QTFRED_HELP_QCH}"
-        "$<TARGET_FILE_DIR:qtfred>/qtfred_help.qch"
+        "$<TARGET_FILE_DIR:qtfred>/help/qtfred_help.qch"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${QTFRED_HELP_QHC}"
+        "$<TARGET_FILE_DIR:qtfred>/help/qtfred_help.qhc"
     VERBATIM)
 
-install(FILES "${QTFRED_HELP_QCH}"
-    DESTINATION ${BINARY_DESTINATION}
+install(FILES "${QTFRED_HELP_QCH}" "${QTFRED_HELP_QHC}"
+    DESTINATION ${BINARY_DESTINATION}/help
     COMPONENT "qtFRED")
 # --- end QtFRED built-in help ---
 

--- a/qtfred/src/mission/dialogs/HelpTopicsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/HelpTopicsDialogModel.cpp
@@ -5,10 +5,8 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QtHelp/QHelpEngine>
-#include <QHelpEngineCore>
 #include <QHelpSearchEngine>
 #include <QRegularExpression>
-#include <QStandardPaths>
 
 #include "cfile/cfile.h"
 
@@ -62,13 +60,16 @@ bool HelpTopicsDialogModel::ensureEngineReady() {
 		return !_helpEngine->registeredDocumentations().isEmpty();
 
 	const QString collectionFile = resolveCollectionFile();
-	if (collectionFile.isEmpty()) {
-		mprintf(("QtFRED help: could not determine a writable location for the help collection\n"));
+	if (!QFileInfo::exists(collectionFile)) {
+		mprintf(("QtFRED help: collection file not found at %s\n",
+		         collectionFile.toUtf8().constData()));
 		return false;
 	}
 
 	// Parent to qApp so Qt manages the lifetime. Destroyed cleanly before the event loop exits.
+	// The .qhc ships with the application with the .qch already registered. We open it as read-only.
 	_helpEngine = new QHelpEngine(collectionFile, qApp);
+	_helpEngine->setReadOnly(true);
 	if (!_helpEngine->setupData()) {
 		mprintf(("QtFRED help: could not initialize engine: %s\n",
 		         _helpEngine->error().toUtf8().constData()));
@@ -77,58 +78,13 @@ bool HelpTopicsDialogModel::ensureEngineReady() {
 		return false;
 	}
 
-	const QString contentFile = resolveContentFile();
-	if (contentFile.isEmpty()) {
-		mprintf(("QtFRED help: could not find qtfred_help.qch\n"));
-		delete _helpEngine;
-		_helpEngine = nullptr;
-		return false;
-	}
-
-	const QString ns = QHelpEngineCore::namespaceName(contentFile);
-	if (!ns.isEmpty()) {
-		// Always unregister and re-register.  Qt copies file content from the .qch into the
-		// .qhc SQLite database at registration time.  If the .qch is rebuilt without
-		// re-registration the .qhc tables become stale: findFile() succeeds but fileData()
-		// returns 0 bytes.  Forcing re-registration each startup is cheap and guarantees the
-		// collection database is always in sync with the current .qch.
-		if (_helpEngine->registeredDocumentations().contains(ns))
-			_helpEngine->unregisterDocumentation(ns);
-
-		if (!_helpEngine->registerDocumentation(contentFile)) {
-			mprintf(("QtFRED help: failed to register %s: %s\n",
-			         contentFile.toUtf8().constData(),
-			         _helpEngine->error().toUtf8().constData()));
-		} else {
-			mprintf(("QtFRED help: registered namespace '%s' from %s\n",
-			         ns.toUtf8().constData(),
-			         contentFile.toUtf8().constData()));
-		}
-	}
-
 	return !_helpEngine->registeredDocumentations().isEmpty();
 }
 
 // ---------------------------------------------------------------------------
 QString HelpTopicsDialogModel::resolveCollectionFile() {
-	const QString appDataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-	if (appDataDir.isEmpty())
-		return {};
-	QDir(appDataDir).mkpath(QStringLiteral("help"));
-	return QDir(appDataDir).filePath(QStringLiteral("help/qtfred.qhc"));
-}
-
-QString HelpTopicsDialogModel::resolveContentFile() {
-	// Check the FSO VFS for a mod override in data/freddocs/.
-	if (cfile_inited) {
-		CFileLocation loc = cf_find_file_location("qtfred_help.qch", CF_TYPE_FREDDOCS);
-		if (loc.found && !loc.full_name.empty())
-			return QString::fromStdString(loc.full_name);
-	}
-
-	// Fall back to the built-in .qch deployed next to the executable.
 	return QDir(QCoreApplication::applicationDirPath()).filePath(
-	    QStringLiteral("help/qtfred_help.qch"));
+	    QStringLiteral("help/qtfred_help.qhc"));
 }
 
 // ---------------------------------------------------------------------------

--- a/qtfred/src/mission/dialogs/HelpTopicsDialogModel.h
+++ b/qtfred/src/mission/dialogs/HelpTopicsDialogModel.h
@@ -48,7 +48,6 @@ public:
 
 private:
 	static QString resolveCollectionFile();
-	static QString resolveContentFile();
 	static QString extractHtmlTitle(const QString& filePath);
 	static QList<TutorialEntry> discoverTutorials();
 


### PR DESCRIPTION
Fixes QtFred help generation to build-time instead of run time and removes qch from freddocs as a valid file type.